### PR TITLE
Add mise.toml and biome tooling to frontend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,24 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  lint-format-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: jdx/mise-action@v2
+
+      - name: Lint
+        run: mise run lint
+
+      - name: Format check
+        run: mise run format
+
+      - name: Test
+        run: mise run test

--- a/frontend/biome.json
+++ b/frontend/biome.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "organizeImports": {
+    "enabled": true
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "trailingCommas": "es5"
+    }
+  }
+}

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -6,7 +6,11 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "lint": "eslint .",
+    "lint": "biome check src",
+    "lint:fix": "biome check --write src",
+    "format": "biome format src",
+    "format:write": "biome format --write src",
+    "test": "echo 'No tests configured'",
     "preview": "vite preview"
   },
   "dependencies": {
@@ -15,6 +19,7 @@
     "react-router-dom": "7.1.5"
   },
   "devDependencies": {
+    "@biomejs/biome": "^1.9.4",
     "@types/react": "^19.0.8",
     "@types/react-dom": "^19.0.3",
     "@vitejs/plugin-react": "^4.3.4",

--- a/mise.toml
+++ b/mise.toml
@@ -1,0 +1,14 @@
+[tools]
+node = "22"
+
+[tasks.install]
+run = "make install"
+
+[tasks.lint]
+run = "cd frontend && yarn install --immutable && yarn lint"
+
+[tasks.format]
+run = "cd frontend && yarn install --immutable && yarn format:write"
+
+[tasks.test]
+run = "cd frontend && yarn test"


### PR DESCRIPTION
Sets up mise tooling with:
- Node 22
- install: make install (installs both frontend and backend)
- lint: biome check in frontend (added biome + scripts)
- format: biome format --write in frontend (added biome + scripts)
- test: placeholder in frontend

Added to frontend/:
- biome.json config
- @biomejs/biome dev dependency
- Updated scripts to use biome instead of eslint

Part of standardizing mise.toml across all repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)